### PR TITLE
Update the default notification limit

### DIFF
--- a/Compass/src/Model/User.swift
+++ b/Compass/src/Model/User.swift
@@ -20,7 +20,7 @@ class User: TDCBase, CustomStringConvertible{
     private var token: String = "";
     private var dateJoined: String = "";
     private var needsOnBoardingVar: Bool = true;
-    private var dailyNotificationLimit = 0;
+    private var dailyNotificationLimit = 3;  // Default to 3, otherwise this will get set to 0 when the user signs up.
     
     //Profile answers
     private var zipCode: String = "";


### PR DESCRIPTION
When user signs up, they'll go thru on-boarding, but as soon as they hit the feed we update their profile settings. Previously this would set their daily notification value to 0. This PR sets it to the same default we use on the backend.